### PR TITLE
Add aggregate by ps spaces

### DIFF
--- a/dags/crossclient_aggregation.py
+++ b/dags/crossclient_aggregation.py
@@ -23,12 +23,16 @@ queries = {
     "components": """SELECT id AS component_id, manifest_name, component_name, published_at, ps_title, ps_subtitle, ps_type
                     FROM prod.components""",
     "participatory_spaces" : """WITH participatory_processes AS (
-                    SELECT type, id, title, slug, published_at FROM prod.stg_decidim_participatory_processes
+                    SELECT type, id, title, slug, published_at
+                    FROM prod.stg_decidim_participatory_processes
                     ), assemblies AS (
                     SELECT 'assembly' AS type, id, title, slug, published_at
                     FROM prod.stg_decidim_assemblies
+                    ), initiatives AS (
+                    SELECT 'initiatives' AS type, 0 AS id, 'N/A' AS title, 'N/A' AS slug, NULL AS published_at
+                    FROM prod.stg_decidim_initiatives LIMIT 1
                     )
-                    SELECT * FROM participatory_processes UNION ALL SELECT * FROM assemblies"""}
+                    SELECT * FROM participatory_processes UNION ALL SELECT * FROM initiatives UNION ALL SELECT * FROM assemblies"""}
 
 with DAG(
         dag_id='crossclient_aggregation',

--- a/dags/crossclient_aggregation.py
+++ b/dags/crossclient_aggregation.py
@@ -21,7 +21,14 @@ queries = {
     "processes": """SELECT id AS ps_id, title, subtitle, published_at
                     FROM prod.stg_decidim_participatory_processes""",
     "components": """SELECT id AS component_id, manifest_name, component_name, published_at, ps_title, ps_subtitle, ps_type
-                    FROM prod.components"""}
+                    FROM prod.components""",
+    "participatory_spaces" : """WITH participatory_processes AS (
+                    SELECT type, id, title, slug, published_at FROM prod.stg_decidim_participatory_processes
+                    ), assemblies AS (
+                    SELECT 'assembly' AS type, id, title, slug, published_at
+                    FROM prod.stg_decidim_assemblies
+                    )
+                    SELECT * FROM participatory_processes UNION ALL SELECT * FROM assemblies"""}
 
 with DAG(
         dag_id='crossclient_aggregation',


### PR DESCRIPTION
- Initiatives only show up once per client if `decidim_initiatives` is not empty
- Conferences are not taken into account since the `decidim_conferences` table is not in Airbyte