### PR TITLE
Coerce grist values before dumping

### DIFF
--- a/dags/data_utils/grist/grist_utils.py
+++ b/dags/data_utils/grist/grist_utils.py
@@ -1,0 +1,40 @@
+from airflow.hooks.base import BaseHook
+from grist_api import GristDocAPI
+import pandas as pd
+from airflow.models import Variable
+
+# Retrieve the connection object using Airflow's BaseHook
+connection = BaseHook.get_connection("grist_osp")
+grist_api_key = connection.password
+grist_server = connection.host
+
+
+def fetch_grist_table_data(doc_id, table_name, errors="coerce"):
+    """
+    Fetch data from a Grist table and return it as a pandas DataFrame with type validation.
+
+    Args:
+        doc_id (str): The Grist document ID to fetch data from
+        table_name (str): Name of the Grist table to fetch data from
+
+    Returns:
+        pandas.DataFrame: The fetched data from Grist with validated data types
+    """
+    # Create Grist API instance with the provided document ID
+    api = GristDocAPI(doc_id, server=grist_server, api_key=grist_api_key)
+
+    # Fetch data from Grist table
+    data = api.fetch_table(table_name)
+    df = pd.DataFrame(data)
+
+    # Validate and clean data types
+    # Grist does not have strict typing: string values can
+    # be stored in numerical columns. To avoir sql errors,
+    # we replace these values by none.
+    for column in df.columns:
+        # Handle numeric columns - convert invalid values to NaN
+        if df[column].dtype == "object":
+            # Try to convert to numeric, replacing non-numeric values with NaN
+            df[column] = pd.to_numeric(df[column], errors=errors)
+
+    return df

--- a/dags/data_utils/postgres_helper/postgres_helper.py
+++ b/dags/data_utils/postgres_helper/postgres_helper.py
@@ -2,6 +2,7 @@ from sqlalchemy import create_engine, text
 from airflow.hooks.base import BaseHook
 import logging
 
+
 def get_postgres_connection(connection_name, database):
     """Extracts PostgreSQL connection details from Airflow and establishes a connection."""
     try:
@@ -17,42 +18,32 @@ def get_postgres_connection(connection_name, database):
         # Create the SQLAlchemy engine
         return create_engine(f"postgresql://{user}:{password}@{host}:{port}/{database}")
 
-
     except Exception as e:
         print(f"Failed to connect to PostgreSQL using Airflow connection: {e}")
         raise  # Raise exception to ensure the DAG fails if the connection cannot be established
 
+
 # Clean data in PostgreSQL within the date range
 def drop_table_in_postgres(connection, table_name):
-    """Deletes rows in the table where the 'date' is between the start_date and end_date."""
+    """Drops the table if it exists."""
     try:
-        delete_query = text(
-            f"DROP TABLE {table_name}"
-        )
-        connection.execute(delete_query)
-        print(f"Cleaned data in {table_name}")
+        # Check if table exists and drop it only if it does
+        drop_query = text(f"DROP TABLE IF EXISTS {table_name}")
+        connection.execute(drop_query)
+        print(f"Dropped table {table_name} if it existed")
     except Exception as e:
-        print(f"Failed to clean data in {table_name}: {e}")
-
-
-# Clean data in PostgreSQL within the date range
-def clean_data_in_postgres(connection, table_name, start_date, end_date):
-    """Deletes rows in the table where the 'date' is between the start_date and end_date."""
-    try:
-        delete_query = text(
-            f"DELETE FROM {table_name} WHERE date BETWEEN :start_date AND :end_date"
-        )
-        connection.execute(delete_query, {'start_date': start_date, 'end_date': end_date})
-        print(f"Cleaned data in {table_name} between {start_date} and {end_date}.")
-    except Exception as e:
-        print(f"Failed to clean data in {table_name}: {e}")
+        print(f"Failed to drop table {table_name}: {e}")
 
 
 # Dump DataFrame to PostgreSQL table
-def dump_data_to_postgres(connection, data, table_name, schema='public', if_exists='append'):
+def dump_data_to_postgres(
+    connection, data, table_name, schema="public", if_exists="append"
+):
     """Dumps the DataFrame into the specified PostgreSQL table."""
     try:
-        data.to_sql(table_name, connection, schema=schema, if_exists=if_exists, index=False)
+        data.to_sql(
+            table_name, connection, schema=schema, if_exists=if_exists, index=False
+        )
         print(f"Data for {table_name} dumped successfully into the table.")
     except Exception as e:
         print(f"Failed to dump data into {table_name}: {e}")


### PR DESCRIPTION
In grist, values are not strongly typed. This caused error when tables had string like "to check" for numerical column.

This PR uses a new fetch function that checks for untyped column before dumping.